### PR TITLE
Check number and values of testee results

### DIFF
--- a/should-test.lisp
+++ b/should-test.lisp
@@ -167,7 +167,8 @@
 (defmethod should-check ((key (eql :be)) test fn &rest expected)
   (let ((rez (multiple-value-list (funcall fn))))
     (or (if expected
-            (every test rez (mklist expected))
+            (and (>= (length rez) (length expected))
+                 (every test rez (mklist expected)))
             (every test rez))
         (values nil
                 rez))))


### PR DESCRIPTION
Add a check that there are at least as many values return from the tested form as listed in the list of expected values.  This doesn't assert equality because there are situations where you will return more than one value, but you only care about the first several (e.g. a function that ends with a call to gethash may not care about the second return value).